### PR TITLE
add left shift to shifting off the first bit for a uint -> int conver…

### DIFF
--- a/mersenne_twister_32/mersenne_twister_32.go
+++ b/mersenne_twister_32/mersenne_twister_32.go
@@ -273,7 +273,7 @@ func (m *MT19937) Int31() int32 {
 	y ^= (y << 15) & 0xefc60000
 	y ^= (y >> 18)
 
-	return int32(y >> 1)
+	return int32(y & LMask)
 }
 
 // Int returns a random, non-negative int.

--- a/mersenne_twister_64/mersenne_twister_64.go
+++ b/mersenne_twister_64/mersenne_twister_64.go
@@ -243,7 +243,7 @@ func (m *MT19937) Int64() uint64 {
 // Int63 generates a random number on [0, 2^63-1]-interval from the given
 // MT19937.
 func (m *MT19937) Int63() int64 {
-	return int64((m.Int64() >> 1))
+	return int64((m.Int64() << 1 >> 1))
 }
 
 // IntN generates a random number on [0, 2^64-1]-interval within


### PR DESCRIPTION
…sion

This fixes a bug in the way the uint -> int conversion was done; which lead to changing the resulting value for values that wouldn't overflow an int: e.g. 256 became 128.
